### PR TITLE
convert caption to lowercase.

### DIFF
--- a/polybot/bot.py
+++ b/polybot/bot.py
@@ -128,7 +128,7 @@ class ObjectDetectionBot(Bot):
 
                 logger.info("\nFilter set to Predict\n")
 
-            if self.filter == "Predict":
+            if self.filter.lower() == "predict":
                 photo_path = self.download_user_photo(msg)
 
                 logger.info(f"\nDownload image: {self.images_bucket}\n")


### PR DESCRIPTION
I converted the filter's caption to lowercase within the if statement to omit the requirement of an upper case first letter